### PR TITLE
Dont raise exceptions for bad signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - '3.4'
 
 before_install:
+  - 'travis_retry sudo apt-get update'
   - 'travis_retry sudo apt-get install python-dev libxml2-dev libxmlsec1-dev'
   - 'travis_retry pip install Cython --use-mirrors'
 

--- a/saml/__init__.py
+++ b/saml/__init__.py
@@ -9,13 +9,14 @@ Language (SAML) v2.0 messages.
 """
 # Version of the library.
 from ._version import __version__, __version_info__  # noqa
-VERSION = __version__
 
 # Version of the SAML standard supported.
 from .schema import VERSION as SAML_VERSION
 
 from .signature import sign, verify
 from . import client
+
+VERSION = __version__
 
 __all__ = [
     'VERSION',

--- a/saml/signature.py
+++ b/saml/signature.py
@@ -73,8 +73,6 @@ def verify(xml, stream):
 
     # Verify the signature.
     try:
-        ctx.verify(signature_node)
+        return ctx.verify(signature_node)
     except RuntimeError:
         return False
-    else:
-        return True

--- a/saml/signature.py
+++ b/saml/signature.py
@@ -48,7 +48,7 @@ def verify(xml, stream):
     signature_node = xmlsec.tree.find_node(xml, xmlsec.Node.SIGNATURE)
     if signature_node is None:
         # No `signature` node found; we cannot verify
-        return None
+        return False
 
     # Create a digital signature context (no key manager is needed).
     ctx = xmlsec.SignatureContext()
@@ -72,4 +72,9 @@ def verify(xml, stream):
     ctx.key = key
 
     # Verify the signature.
-    return ctx.verify(signature_node)
+    try:
+        ctx.verify(signature_node)
+    except RuntimeError:
+        return False
+    else:
+        return True

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -303,15 +303,6 @@ def test_generic_deserialize_outside_registry():
     assert result is None
 
 
-# NAMES = [
-#     'assertion',
-#     'response',
-#     'logout-response',
-#     'artifact-resolve',
-#     'artifact-response'
-# ]
-
-
 @mark.parametrize('name', NAMES)
 def test_sign(name):
     # Load the expected result.
@@ -329,10 +320,6 @@ def test_sign(name):
     with open(path.join(BASE_DIR, 'rsakey.pem'), 'r') as stream:
         # Sign the result.
         saml.sign(result, stream)
-
-    # print()
-    # print(etree.tostring(result).decode('utf8'))
-    # print()
 
     # Compare the nodes.
     assert_node(expected, result)
@@ -358,7 +345,7 @@ def test_verify_with_bad_signature_returns_False(name):
     signature_node.clear()
 
     with open(path.join(BASE_DIR, 'rsapub.pem'), 'r') as stream:
-        assert saml.verify(expected, stream) == False
+        assert saml.verify(expected, stream) is False
 
 
 @mark.parametrize('name', NAMES)
@@ -367,4 +354,4 @@ def test_verify_with_no_signature_returns_False(name):
     expected = etree.parse(filename).getroot()
 
     with open(path.join(BASE_DIR, 'rsapub.pem'), 'r') as stream:
-        assert saml.verify(expected, stream) == False
+        assert saml.verify(expected, stream) is False

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,7 +5,7 @@ from saml.schema import utils
 from datetime import datetime
 from lxml import etree
 from os import path
-from pytest import mark, raises
+from pytest import mark
 
 BASE_DIR = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
The `verify` function is a bit confusing. Currently when a document's signature is invalid, a `RuntimeError` is raised. When a document has no signature, the function returns `None`. This changes the function to return `False` in both of those cases. Also:

 * PEP8 fixes
 * Removed commented-out code
 * Fixed Travis build